### PR TITLE
Modular i/o: Crow, Just Friends, w/

### DIFF
--- a/colorwheel.lua
+++ b/colorwheel.lua
@@ -10,6 +10,7 @@
 include 'lib/core'
 include 'lib/norns'
 include 'lib/grid'
+include 'lib/notes'
 include 'lib/algebra'
 lattice = require("lib/lattice")
 
@@ -1979,6 +1980,7 @@ seqorlive:connect { g = grid.connect() }
 function init()
     screen.clear()
     algebra.init()
+    notes.init()
     my_lattice = lattice:new()
     ppqn = 16
   gate_transport_1 = my_lattice:new_pattern{

--- a/lib/algebra.lua
+++ b/lib/algebra.lua
@@ -72,6 +72,9 @@ queue_add_param{ type = "number", id = "current length step " ..i, name = "curre
 
   dequeue_param_group("track " ..i)
   params:set_action("output "..i, function(param)
+    if param == JF_VOICE then
+      crow.ii.jf.mode(1)
+    end
     if not currently_banging then
       currently_banging = true
       params:bang()

--- a/lib/algebra.lua
+++ b/lib/algebra.lua
@@ -1,7 +1,5 @@
 music_util = require("musicutil")
 
-m = midi.connect()
-
 -- store params until ready to add to group
 local param_queue = {}
 function queue_add_param(param)
@@ -43,6 +41,7 @@ end
 
 for i = 1,4,1
   do
+    queue_add_param{ type = "option", id = "output "..i, name = "output", options= VOICES, default=MIDI_VOICE}
 queue_add_param{ type = "number", id = "gate div " ..i, name = "gate div " ..i, min = 1, max = 16, default = 1}
 queue_add_param{ type = "number", id = "interval div " ..i, name = "interval div " ..i, min = 1, max = 16, default = 1}
 queue_add_param{ type = "number", id = "octave div " ..i, name = "gate div " ..i, min = 1, max = 16, default = 1}
@@ -72,7 +71,13 @@ queue_add_param{ type = "number", id = "current velocity step " ..i, name = "cur
 queue_add_param{ type = "number", id = "current length step " ..i, name = "current length step " ..i, min = 1, max = 16, default = 1}
 
   dequeue_param_group("track " ..i)
-
+  params:set_action("output "..i, function(param)
+    if not currently_banging then
+      currently_banging = true
+      params:bang()
+      currently_banging = false
+    end
+  end)
 end
 
 for i = 1,4,1 do
@@ -495,24 +500,9 @@ end
 
 function play(note, vel, length, channel, track)
   if math.random(1, 100) <= params:get('probability ' ..track) and params:get("track active " ..track) >= 1 then
-  if math.random(1,100) <= params:get('gate probability 1 ' ..params:get("current gate step 1" )) then
-  m:note_on(note, vel, channel)
-  end end
-  clock.run(note_off, note, vel, length, channel, track)
-  print(velocity, current_velocity_1, previous_velocity_1, current_velocity_2, previous_velocity_2)
-end
-
-function note_off(note, vel, length, channel)
-      clock.sleep(clock.get_beat_sec() * length)
-       m:note_off(note, vel, channel)
-end
-
-function m:all_off()
-  for note = 1, 127 do
-    for channel = 1, 16 do
-      for device = 1, 4 do
-        m:note_off(note, 0, channel)
-      end
-    end
+    if math.random(1,100) <= params:get('gate probability 1 ' ..params:get("current gate step 1" )) then
+      notes.play[params:get('output '..track)](note, vel, length, channel, track)
+    end 
   end
+  print(velocity, current_velocity_1, previous_velocity_1, current_velocity_2, previous_velocity_2)
 end

--- a/lib/notes.lua
+++ b/lib/notes.lua
@@ -1,0 +1,185 @@
+VOICES = {"midi", "w/syn"}
+
+MIDI_VOICE = 1
+WSYN_VOICE = 2
+
+notes = {}
+
+function curve_formatter(param)
+  local c = param:get()
+  local description = "square"
+  if c == -5 then description = "pulse"
+  elseif c < 0 then description = "trapezoid"
+  elseif c == 0 then description = "saw/triangle"
+  elseif c < 5 then description = "rounded"
+  else description = "sinusoid"
+  end
+  return string.format("%.1f %s", c, description)
+end
+
+function ifoutput(opt, f)
+  return function(param)
+    local doit = false
+    for i = 1,4,1 do
+      if params:get("output "..i) == opt then
+        doit = true
+      end
+    end
+    if doit then f(param) end
+  end
+end
+
+WSYN_SUSTAIN = 1
+WSYN_PLUCK = 2
+
+
+
+function notes.init()
+  local V5_default0 = controlspec.def{
+    min=-5.0,
+    max=5.0,
+    warp='lin',
+    step=0.00,
+    default=0.0,
+    quantum=0.01,
+    wrap=false,
+    units='V'
+  }
+
+  local V5_default1 = controlspec.def{
+    min=-5.0,
+    max=5.0,
+    warp='lin',
+    step=0.00,
+    default=1.0,
+    quantum=0.01,
+    wrap=false,
+    units='V'
+  }  
+
+  local V5_default5 = controlspec.def{
+    min=-5.0,
+    max=5.0,
+    warp='lin',
+    step=0.00,
+    default=5.0,
+    quantum=0.01,
+    wrap=false,
+    units='V'
+  }
+  
+  local V5_default_neg5 = controlspec.def{
+    min=-5.0,
+    max=5.0,
+    warp='lin',
+    step=0.00,
+    default= -5.0,
+    quantum=0.01,
+    wrap=false,
+    units='V'
+  }
+  
+  local N16 = controlspec.def{
+    min=1,
+    max=16,
+    warp='lin',
+    step=1,
+    default=1,
+    quantum=0.01,
+    wrap=false,
+    units=''
+  }
+  
+  local v5 = controlspec.new(-5.0, 5.0, 'lin', 0, 0.0, "", 0.1, false)
+
+  params:add_group("w/syn",9)
+  
+  params:add_option("w/style", "style", {"sustain", "pluck"}, 1)
+  params:set_action("w/style", ifoutput(WSYN_VOICE, function (param)
+    crow.ii.wsyn.ar_mode(param - 1)
+    crow.ii.wsyn.voices(4)
+  end))
+  
+  params:add_control("w/curve", "curve", V5_default5)
+  params:set_action("w/curve", ifoutput(WSYN_VOICE, function(param)
+    crow.ii.wsyn.curve(param)
+  end))
+  
+  params:add_control("w/ramp", "ramp", V5_default0)
+  params:set_action("w/ramp", ifoutput(WSYN_VOICE, function(param)
+    crow.ii.wsyn.ramp(param)
+  end))
+  
+  params:add_control("w/fm_index", "fm index", V5_default1)
+  params:set_action("w/fm_index", ifoutput(WSYN_VOICE, function(param)
+    crow.ii.wsyn.fm_index(param)
+  end))
+  
+  params:add_control("w/fm_env", "fm envelope", V5_default1)
+  params:set_action("w/fm_env", ifoutput(WSYN_VOICE, function(param)
+    crow.ii.wsyn.fm_env(param)
+  end))
+  
+  params:add_control("w/fm_num", "ratio numerator", N16)
+  params:set_action("w/fm_num", ifoutput(WSYN_VOICE, function(param)
+    crow.ii.wsyn.fm_ratio(param, params:get("w/fm_denom"))
+  end))
+  
+  params:add_control("w/fm_denom", "ratio denominator", N16)
+  params:set_action("w/fm_denom", ifoutput(WSYN_VOICE, function(param)
+    crow.ii.wsyn.fm_ratio(params:get("w/fm_num"), param)
+  end))
+  
+  params:add_control("w/lpg_time", "lpg time", V5_default0)
+  params:set_action("w/lpg_time", ifoutput(WSYN_VOICE, function(param)
+    crow.ii.wsyn.lpg_time(param)
+  end))
+  
+  params:add_control("w/lpg_symmetry", "lpg symmetry", V5_default_neg5)
+  params:set_action("w/lpg_symmetry", ifoutput(WSYN_VOICE, function(param)
+    crow.ii.wsyn.lpg_symmetry(param)
+  end))
+end
+
+m = midi.connect()
+
+
+
+function play_midi_note(note, vel, length, channel, track)
+  m:note_on(note, vel, channel)
+  clock.run(midi_note_off, note, vel, length, channel, track)
+end
+
+function play_wsyn_note(note, vel, length, channel, track)
+  local v8 = (note - 60)/12
+  local v_vel = (vel/127) * 5
+  if params:get("w/style") == WSYN_SUSTAIN then
+    crow.ii.wsyn.play_voice(track, v8, v_vel)
+    clock.run(function() 
+      clock.sleep(clock.get_beat_sec() * length)
+      crow.ii.wsyn.velocity(track, 0)
+    end)
+  else
+    crow.ii.wsyn.play_note(v8, v_vel)
+  end
+end
+
+notes.play = {
+  play_midi_note,
+  play_wsyn_note,
+}
+
+function midi_note_off(note, vel, length, channel)
+  clock.sleep(clock.get_beat_sec() * length)
+  m:note_off(note, vel, channel)
+end
+
+function m:all_off()
+  for note = 1, 127 do
+    for channel = 1, 16 do
+      for device = 1, 4 do
+        m:note_off(note, 0, channel)
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this PR you can now assign an "output" per track, to one of MIDI, w/, JF, crow 1,2, and crow 3,4

Each of these new options now has its own parameter settings to govern how it works, including portomento and legato options and envelope controls for Crow, and all synth params for w/.

There are voicing options for w/ and JF: either they function as a monosynth per track, or dynamically allocate voices among all tracks.