### PR TITLE
'lfast' -> 'last' typo

### DIFF
--- a/lib/pset_sequencer.lua
+++ b/lib/pset_sequencer.lua
@@ -247,7 +247,7 @@ pset_seq.init = function (pset_exclusion_tables, pset_exclusion_table_labels)
   params:add_number("pset_exclusion_first", "first", 1, pset_seq.get_num_psets(), 1)
   params:set_action("pset_exclusion_first", function(val) 
     set_pset_exclusion_first(val)
-    set_pset_exclusion_lfast()
+    set_pset_exclusion_last()
   end )
   
 


### PR DESCRIPTION
hihi @yams7457 !
from https://llllllll.co/t/error-init/56372/12, there's a small typo in the pset sequencer file (which seems corrected in the `flora` repo) that's causing `params:bang()` to error out. seems to be working on my end with this change, lmk if i can help with anything else! <3